### PR TITLE
Updates to make azd compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ To test the app, run `uvicorn main:app` in the integrated terminal, or press `F5
 ## Code to help deploy the app on the cloud
 This repo uses Azure Developer CLI to create two Azure Container Apps: one for the API and the other for the vector database (using Redis), then deploys the app. You can use the following commands to invoke the deployment flow:
 ```bash
-azd login --use-device-code
-azd env new {your unique env name}
+azd auth login
+azd init --template minsa110/devcontainer-fastapi
 azd env set BEARER_TOKEN footoken
 azd env set OPENAI_API_KEY {your open ai key}
 azd up

--- a/azure.yaml
+++ b/azure.yaml
@@ -4,12 +4,8 @@ name: fastapi-app
 metadata:
   template: fastapi-app@0.0.1-beta
 services:
-  api:
-    project: ./server
-    language: py
-    host: containerapp
-    module: app/api
-    docker:
-      path: ./Dockerfile
-      context: ../
-      platform: amd64
+    api:
+        project: .
+        language: py
+        module: app/api
+        host: containerapp

--- a/azure.yaml
+++ b/azure.yaml
@@ -4,8 +4,8 @@ name: fastapi-app
 metadata:
   template: fastapi-app@0.0.1-beta
 services:
-    api:
-        project: .
-        language: py
-        module: app/api
-        host: containerapp
+  api:
+    project: ./
+    language: py
+    module: app/api
+    host: containerapp

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 PLUGIN_HOSTNAME=$(echo "$PLUGIN_HOSTNAME" | sed 's/^"//' | sed 's/"$//')
-sed -i 's|https://your-app-url.com|'$PLUGIN_HOSTNAME'|g' ./.well-known/ai-plugin.json ./.well-known/openapi.yaml ./server/main.py
+sed -i 's|https://your-app-url.com|'$PLUGIN_HOSTNAME'|g' ./ai-plugin.json ./openapi.yaml ./main.py
 
-exec uvicorn server.main:app --host 0.0.0.0 --port "${PORT:-${WEBSITES_PORT:-8080}}"
+exec uvicorn main:app --host 0.0.0.0 --port "${PORT:-${WEBSITES_PORT:-8080}}"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,196 @@
+openapi: 3.0.2
+info:
+  title: Retrieval Plugin API
+  description: A retrieval API for querying and filtering documents based on natural language queries and metadata
+  version: 1.0.0
+  servers:
+    - url: https://your-app-url.com
+paths:
+  /query:
+    post:
+      summary: Query
+      description: Accepts search query objects array each with query and optional filter. Break down complex questions into sub-questions. Refine results by criteria, e.g. time / source, don't do this often. Split queries if ResponseTooLargeError occurs.
+      operationId: query_query_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueryRequest"
+        required: true
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueryResponse"
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPValidationError"
+      security:
+        - HTTPBearer: []
+components:
+  schemas:
+    DocumentChunkMetadata:
+      title: DocumentChunkMetadata
+      type: object
+      properties:
+        source:
+          $ref: "#/components/schemas/Source"
+        source_id:
+          title: Source Id
+          type: string
+        url:
+          title: Url
+          type: string
+        created_at:
+          title: Created At
+          type: string
+        author:
+          title: Author
+          type: string
+        document_id:
+          title: Document Id
+          type: string
+    DocumentChunkWithScore:
+      title: DocumentChunkWithScore
+      required:
+        - text
+        - metadata
+        - score
+      type: object
+      properties:
+        id:
+          title: Id
+          type: string
+        text:
+          title: Text
+          type: string
+        metadata:
+          $ref: "#/components/schemas/DocumentChunkMetadata"
+        embedding:
+          title: Embedding
+          type: array
+          items:
+            type: number
+        score:
+          title: Score
+          type: number
+    DocumentMetadataFilter:
+      title: DocumentMetadataFilter
+      type: object
+      properties:
+        document_id:
+          title: Document Id
+          type: string
+        source:
+          $ref: "#/components/schemas/Source"
+        source_id:
+          title: Source Id
+          type: string
+        author:
+          title: Author
+          type: string
+        start_date:
+          title: Start Date
+          type: string
+        end_date:
+          title: End Date
+          type: string
+    HTTPValidationError:
+      title: HTTPValidationError
+      type: object
+      properties:
+        detail:
+          title: Detail
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationError"
+    Query:
+      title: Query
+      required:
+        - query
+      type: object
+      properties:
+        query:
+          title: Query
+          type: string
+        filter:
+          $ref: "#/components/schemas/DocumentMetadataFilter"
+        top_k:
+          title: Top K
+          type: integer
+          default: 3
+    QueryRequest:
+      title: QueryRequest
+      required:
+        - queries
+      type: object
+      properties:
+        queries:
+          title: Queries
+          type: array
+          items:
+            $ref: "#/components/schemas/Query"
+    QueryResponse:
+      title: QueryResponse
+      required:
+        - results
+      type: object
+      properties:
+        results:
+          title: Results
+          type: array
+          items:
+            $ref: "#/components/schemas/QueryResult"
+    QueryResult:
+      title: QueryResult
+      required:
+        - query
+        - results
+      type: object
+      properties:
+        query:
+          title: Query
+          type: string
+        results:
+          title: Results
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentChunkWithScore"
+    Source:
+      title: Source
+      enum:
+        - email
+        - file
+        - chat
+      type: string
+      description: An enumeration.
+    ValidationError:
+      title: ValidationError
+      required:
+        - loc
+        - msg
+        - type
+      type: object
+      properties:
+        loc:
+          title: Location
+          type: array
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+  securitySchemes:
+    HTTPBearer:
+      type: http
+      scheme: bearer


### PR DESCRIPTION
This PR makes azd up work in Codespaces (I was able to hit the `/todos` endpoint without error). Some notes:

- `azd auth login` will be the new login command as of Monday's 0.8.0 release (I've updated the README proactively but for now it's just `azd login`).
-  `--use-device-code` is not required in Codespaces. It just works as is.
- I've added a file for the `openapi.yaml`  to make that `.sh` work. Not sure if it's needed but could be removed from the script if needed.
- I'm not sure that the docker stuff in the `azure.yaml` are required here. This just works as is.
